### PR TITLE
Fix chat authentication middleware path

### DIFF
--- a/server/routes/chatRoutes.js
+++ b/server/routes/chatRoutes.js
@@ -2,10 +2,10 @@
 const express = require('express');
 const router = express.Router();
 const chatController = require('../controllers/chatController');
-const authMiddleware = require('../middleware/auth');
+const { authenticate } = require('../middlewares/auth');
 
 // Protected routes (require authentication)
-router.use(authMiddleware);
+router.use(authenticate);
 
 // Get all conversations for a user
 router.get('/user/:userId', chatController.getUserConversations);


### PR DESCRIPTION
## Summary
- update chatRoutes.js to import authentication middleware from `middlewares/auth`
- ensure router uses the exported `authenticate` function

## Testing
- `npm test` *(fails: Error: no test specified)*
- `(cd server && npm test)` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a33952154832092e31abee9d3d534