### PR TITLE
Fix server import path

### DIFF
--- a/server/controllers/WishlistController.js
+++ b/server/controllers/WishlistController.js
@@ -1,4 +1,4 @@
-const Wishlist = require("../models/wishlist");
+const Wishlist = require("../models/Wishlist");
 const Vehicle = require("../models/Vehicle");
 
 // GET all saved vehicles for a renter


### PR DESCRIPTION
## Summary
- fix Wishlist model import path on the server

## Testing
- `npm run dev` (fails to connect to MongoDB because `MONGO_URI` is undefined)

------
https://chatgpt.com/codex/tasks/task_e_685a35fd7e508320835705a095672a32